### PR TITLE
[FIX] [SebFox2011] clear action has to clear histories and counter

### DIFF
--- a/src/hooks/useHistoryState.ts
+++ b/src/hooks/useHistoryState.ts
@@ -55,6 +55,7 @@ export default function useHistoryState<T>(
   const historyClear = useCallback(() => {
     historyRef.current = [];
     forceUpdate((prev) => prev + 1);
+    setState(initialState)
   }, [historyRef, forceUpdate]);
 
   const setStateCallback = useCallback(


### PR DESCRIPTION
Not sure but, in the useHistoryState, clear action must clear history and counter in the same time.