### PR TITLE
refactor: :rotating_light: Name useCookie Hook to avoid Eslint warning

### DIFF
--- a/src/hooks/useCookie.ts
+++ b/src/hooks/useCookie.ts
@@ -16,7 +16,7 @@ type CookiesReturn = [
  * 2. A function to update the cookie value.
  * 3. A function to delete the cookie.
  */
-export default function (cookieName: string): CookiesReturn {
+export default function useCookie(cookieName: string): CookiesReturn {
   const [value, setValue] = useState<string | null>(
     () => Cookies.get(cookieName) || null,
   );


### PR DESCRIPTION
In JavaScript and React projects, it is possible to export an anonymous function as a default export, but ESLint may display a warning or error because anonymous functions make debugging and code analysis more difficult. Indeed, when an anonymous function is exported by default, the function’s name does not appear in the stack trace in case of an error, making the code harder to maintain.

### Error :
`Unexpected default export of anonymous (functioneslintimport/no-anonymous-default-export)`

### Here’s what I suggest to avoid this error:
Give a name to the hook -> `useCookie`